### PR TITLE
Add R-model aliases and correct PH54 specs

### DIFF
--- a/param/dxl_model/dynamixel.model
+++ b/param/dxl_model/dynamixel.model
@@ -35,6 +35,7 @@ Number	Name
 1120	xm540_w270.model
 1130	xm540_w150.model
 1140	xh540_v270.model
+1141	xh540_v270_r.model
 1150	xh540_v150.model
 1160	2xc430_w250.model
 1170	xw540_t260.model
@@ -48,6 +49,11 @@ Number	Name
 1270	xw430_t333.model
 1310	xw540_h260.model
 2000	ph42_020_s300.model
+2001	ph42_020_s300_r.model
+2010	ph54_100_s500.model
+2011	ph54_100_s500_r.model
+2020	ph54_200_s500.model
+2021	ph54_200_s500_r.model
 4000	ym070_210_m001.model
 4020	ym070_210_r051.model
 4030	ym070_210_r099.model

--- a/param/dxl_model/ph42_020_s300_r.model
+++ b/param/dxl_model/ph42_020_s300_r.model
@@ -1,0 +1,71 @@
+[type info]
+name	value
+value_of_zero_radian_position	0
+value_of_max_radian_position	303750
+value_of_min_radian_position	-303750
+min_radian	-3.14159265
+max_radian	3.14159265
+velocity_unit	0.01
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+40	4	Acceleration Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+512	1	Torque Enable
+513	1	LED Red
+514	1	LED Green
+515	1	LED Blue
+516	1	Status Return Level
+517	1	Registered Instruction
+518	1	Hardware Error Status
+524	2	Velocity I Gain
+526	2	Velocity P Gain
+528	2	Position D Gain
+530	2	Position I Gain
+532	2	Position P Gain
+536	2	Feedforward 2nd Gain
+538	2	Feedforward 1st Gain
+546	1	Bus Watchdog
+548	2	Goal PWM
+550	2	Goal Current
+552	4	Goal Velocity
+556	4	Profile Acceleration
+560	4	Profile Velocity
+564	4	Goal Position
+568	2	Realtime Tick
+570	1	Moving
+571	1	Moving Status
+572	2	Present PWM
+574	2	Present Current
+576	4	Present Velocity
+580	4	Present Position
+584	4	Velocity Trajectory
+588	4	Position Trajectory
+592	2	Present Input Voltage
+594	1	Present Temperature
+878	1	Backup Ready
+168	2	Indirect Address 1
+634	1	Indirect Data 1
+168	2	Indirect Address Write
+634	1	Indirect Data Write
+296	2	Indirect Address Read
+698	1	Indirect Data Read

--- a/param/dxl_model/ph54_100_s500.model
+++ b/param/dxl_model/ph54_100_s500.model
@@ -1,0 +1,71 @@
+[type info]
+name	value
+value_of_zero_radian_position	0
+value_of_max_radian_position	501923
+value_of_min_radian_position	-501923
+min_radian	-3.14159265
+max_radian	3.14159265
+velocity_unit	0.01
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+40	4	Acceleration Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+512	1	Torque Enable
+513	1	LED Red
+514	1	LED Green
+515	1	LED Blue
+516	1	Status Return Level
+517	1	Registered Instruction
+518	1	Hardware Error Status
+524	2	Velocity I Gain
+526	2	Velocity P Gain
+528	2	Position D Gain
+530	2	Position I Gain
+532	2	Position P Gain
+536	2	Feedforward 2nd Gain
+538	2	Feedforward 1st Gain
+546	1	Bus Watchdog
+548	2	Goal PWM
+550	2	Goal Current
+552	4	Goal Velocity
+556	4	Profile Acceleration
+560	4	Profile Velocity
+564	4	Goal Position
+568	2	Realtime Tick
+570	1	Moving
+571	1	Moving Status
+572	2	Present PWM
+574	2	Present Current
+576	4	Present Velocity
+580	4	Present Position
+584	4	Velocity Trajectory
+588	4	Position Trajectory
+592	2	Present Input Voltage
+594	1	Present Temperature
+878	1	Backup Ready
+168	2	Indirect Address 1
+634	1	Indirect Data 1
+168	2	Indirect Address Write
+634	1	Indirect Data Write
+296	2	Indirect Address Read
+698	1	Indirect Data Read

--- a/param/dxl_model/ph54_200_s500.model
+++ b/param/dxl_model/ph54_200_s500.model
@@ -1,0 +1,71 @@
+[type info]
+name	value
+value_of_zero_radian_position	0
+value_of_max_radian_position	501923
+value_of_min_radian_position	-501923
+min_radian	-3.14159265
+max_radian	3.14159265
+velocity_unit	0.01
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+40	4	Acceleration Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+512	1	Torque Enable
+513	1	LED Red
+514	1	LED Green
+515	1	LED Blue
+516	1	Status Return Level
+517	1	Registered Instruction
+518	1	Hardware Error Status
+524	2	Velocity I Gain
+526	2	Velocity P Gain
+528	2	Position D Gain
+530	2	Position I Gain
+532	2	Position P Gain
+536	2	Feedforward 2nd Gain
+538	2	Feedforward 1st Gain
+546	1	Bus Watchdog
+548	2	Goal PWM
+550	2	Goal Current
+552	4	Goal Velocity
+556	4	Profile Acceleration
+560	4	Profile Velocity
+564	4	Goal Position
+568	2	Realtime Tick
+570	1	Moving
+571	1	Moving Status
+572	2	Present PWM
+574	2	Present Current
+576	4	Present Velocity
+580	4	Present Position
+584	4	Velocity Trajectory
+588	4	Position Trajectory
+592	2	Present Input Voltage
+594	1	Present Temperature
+878	1	Backup Ready
+168	2	Indirect Address 1
+634	1	Indirect Data 1
+168	2	Indirect Address Write
+634	1	Indirect Data Write
+296	2	Indirect Address Read
+698	1	Indirect Data Read

--- a/param/dxl_model/xh540_v270_r.model
+++ b/param/dxl_model/xh540_v270_r.model
@@ -1,0 +1,74 @@
+[type info]
+name	value
+value_of_zero_radian_position	2048
+value_of_max_radian_position	4095
+value_of_min_radian_position	0
+min_radian	-3.14159265
+max_radian	3.14159265
+velocity_unit	0.229
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+56	1	External Port Mode 1
+57	1	External Port Mode 2
+58	1	External Port Mode 3
+63	1	Shutdown
+64	1	Torque Enable
+65	1	LED
+68	1	Status Return Level
+69	1	Registered Instruction
+70	1	Hardware Error Status
+76	2	Velocity I Gain
+78	2	Velocity P Gain
+80	2	Position D Gain
+82	2	Position I Gain
+84	2	Position P Gain
+88	2	Feedforward 2nd Gain
+90	2	Feedforward 1st Gain
+98	1	Bus Watchdog
+100	2	Goal PWM
+102	2	Goal Current
+104	4	Goal Velocity
+108	4	Profile Acceleration
+112	4	Profile Velocity
+116	4	Goal Position
+120	2	Realtime Tick
+122	1	Moving
+123	1	Moving Status
+124	2	Present PWM
+126	2	Present Current
+128	4	Present Velocity
+132	4	Present Position
+136	4	Velocity Trajectory
+140	4	Position Trajectory
+144	2	Present Input Voltage
+146	1	Present Temperature
+152	2	External Port Data 1
+154	2	External Port Data 2
+156	2	External Port Data 3
+168	2	Indirect Address 1
+224	1	Indirect Data 1
+168	2	Indirect Address Write
+224	1	Indirect Data Write
+578	2	Indirect Address Read
+634	1	Indirect Data Read


### PR DESCRIPTION
## Summary
- correct radian range values in PH54 model files
- register R-type models in `dynamixel.model`

## Testing
- `git status --short`
- `colcon` not available, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_68676d9a52748326bea72f6a8c32f5ba